### PR TITLE
Restore autosave-to-MongoDB on the assessment page

### DIFF
--- a/index-3t.html
+++ b/index-3t.html
@@ -352,6 +352,49 @@
         }
 
         let currentEmployeeName = '';
+        let currentAssessmentId = null; // Track current assessment for updates
+
+        function debounce(func, wait) {
+            let timeout;
+            return function (...args) {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => func.apply(this, args), wait);
+            };
+        }
+
+        function collectMetrics() {
+            const metrics = {};
+            document.querySelectorAll('#inputForm input[type="number"]').forEach(input => {
+                metrics[input.id] = parseInt(input.value) || 0;
+            });
+            return metrics;
+        }
+
+        async function autoSaveAssessment() {
+            if (!authManager.isAuthenticated()) return;
+
+            const data = {
+                employeeName: currentEmployeeName || 'Unknown',
+                assessmentDate: new Date().toISOString(),
+                metrics: collectMetrics()
+            };
+
+            try {
+                if (currentAssessmentId) {
+                    await api.updateAssessment(currentAssessmentId, data);
+                    showSuccessMessage('Assessment updated successfully');
+                } else {
+                    const response = await api.createAssessment(data);
+                    currentAssessmentId = response.assessment._id;
+                    showSuccessMessage('Assessment saved to database');
+                }
+            } catch (error) {
+                console.error('Failed to save to MongoDB:', error);
+                showErrorMessage('Could not save to database: ' + error.message);
+            }
+        }
+
+        const debouncedAutoSave = debounce(autoSaveAssessment, 5000);
 
         // Add event listener for employee name input
         document.getElementById('employeeName').addEventListener('input', function (e) {
@@ -361,6 +404,7 @@
                 performanceChart.options.plugins.title.text = currentEmployeeName ? `${currentEmployeeName} - Results` : 'Results';
                 performanceChart.update();
             }
+            debouncedAutoSave();
         });
         async function saveOnly() {
             const formData = new FormData(document.getElementById('inputForm'));
@@ -399,6 +443,7 @@
                 nameInput.value = '';
                 currentEmployeeName = '';
             }
+            currentAssessmentId = null;
 
             // Update chart title
             if (performanceChart) {
@@ -555,10 +600,11 @@
             }
         }
 
-        // Add event listeners to all inputs to update chart on change
+        // Add event listeners to all inputs to update chart and auto-save on change
         document.querySelectorAll('input[type="number"]').forEach(input => {
-            input.addEventListener('change', () => {
+            input.addEventListener('input', () => {
                 updateChart();
+                debouncedAutoSave();
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- `index.html` (symlinked to `index-3t.html`) only exported ratings to a CSV file — it never called `POST`/`PUT /api/assessments`, so assessments never made it into MongoDB and never showed up on the History page.
- Ports the same debounced 5s autosave pattern already working correctly in `app.js` (used by `index-std.html`): creates the assessment on first save, updates it thereafter via `currentAssessmentId`.

## Test plan
- [x] Registered a disposable test account and logged in
- [x] Entered a rating on the assessment page, waited past the 5s debounce
- [x] Confirmed `POST /api/assessments` hit the backend and the document landed in MongoDB with correct data
- [x] Confirmed the assessment appears correctly on the History page
- [x] Cleaned up the disposable test user/assessment from the DB afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore autosave of assessment data to MongoDB on the 3T assessment page using a debounced save mechanism aligned with the standard app behavior.

New Features:
- Add debounced autosave logic to persist assessment data from the 3T assessment page to MongoDB via the assessments API.

Enhancements:
- Trigger autosave on employee name and metric input changes and reset the tracked assessment ID when clearing the form to ensure correct create vs update behavior.